### PR TITLE
feat: scan projects/ layout for session history

### DIFF
--- a/src/chat_plugin/__init__.py
+++ b/src/chat_plugin/__init__.py
@@ -24,9 +24,9 @@ def create_router(state: Any) -> APIRouter:
         session_manager=state.session_manager, event_bus=state.event_bus
     )
 
-    # Extract sessions_dir from amplifierd settings (may be None)
-    sessions_dir = getattr(
-        getattr(state, "settings", None), "sessions_dir", None
+    # Extract projects_dir from amplifierd settings (may be None)
+    projects_dir = getattr(
+        getattr(state, "settings", None), "projects_dir", None
     )
 
     router = APIRouter()
@@ -36,7 +36,7 @@ def create_router(state: Any) -> APIRouter:
         return {"status": "ok", "plugin": "chat"}
 
     router.include_router(create_pin_routes(pin_storage))
-    router.include_router(create_history_routes(sessions_dir, pin_storage))
+    router.include_router(create_history_routes(projects_dir, pin_storage))
     router.include_router(create_command_routes(processor))
     router.include_router(create_static_routes())
     return router

--- a/src/chat_plugin/routes.py
+++ b/src/chat_plugin/routes.py
@@ -73,7 +73,7 @@ def create_pin_routes(pin_storage: PinStorage) -> APIRouter:
 
 
 def create_history_routes(
-    sessions_dir: Path | None,
+    projects_dir: Path | None,
     pin_storage: PinStorage,
 ) -> APIRouter:
     router = APIRouter(prefix="/chat", tags=["chat-history"])
@@ -91,7 +91,7 @@ def create_history_routes(
         caller-side content filtering.
         """
         sessions, total_count = await asyncio.to_thread(
-            scan_sessions, sessions_dir, limit, offset
+            scan_sessions, projects_dir, limit, offset
         )
         pinned_ids = pin_storage.list_pins()
 
@@ -122,7 +122,7 @@ def create_history_routes(
             wanted = _parse_session_id_set(session_ids.split(","))
 
         rows = await asyncio.to_thread(
-            scan_session_revisions, sessions_dir, wanted
+            scan_session_revisions, projects_dir, wanted
         )
         return {"sessions": rows[:limit]}
 
@@ -198,7 +198,7 @@ def create_history_routes(
             )
 
         rows = await asyncio.to_thread(
-            scan_session_revisions, sessions_dir, wanted
+            scan_session_revisions, projects_dir, wanted
         )
         found_ids = {row["session_id"] for row in rows}
 

--- a/src/chat_plugin/session_history.py
+++ b/src/chat_plugin/session_history.py
@@ -1,15 +1,17 @@
-"""Session history — scans amplifierd's sessions_dir to discover past sessions.
+"""Session history — scans amplifierd's projects_dir to discover past sessions.
 
-Adapted from amplifier-distro's session_history.py for amplifierd's flat
+Adapted from amplifier-distro's session_history.py for the project-nested
 directory layout:
 
-    sessions_dir/
-        {session_id}/transcript.jsonl
-        {session_id}/metadata.json
+    projects_dir/
+        {project_slug}/
+            sessions/
+                {session_id}/transcript.jsonl
+                {session_id}/metadata.json
 
 Schema (one dict per session in scan_sessions() output):
     session_id: str             — session directory name
-    cwd: str|None               — working directory from session-info.json
+    cwd: str|None               — working directory decoded from project slug
     parent_session_id: str|None — parent session id from metadata.json
     spawn_agent: str|None       — spawned agent name from metadata.json
     message_count: int          — number of transcript lines with a 'role' key
@@ -26,6 +28,7 @@ import json
 import logging
 import os
 import re
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
 from pathlib import Path
@@ -38,6 +41,39 @@ METADATA_FILENAME = "metadata.json"
 SESSION_INFO_FILENAME = "session-info.json"
 
 _VALID_SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_\-]+$")
+
+
+def _decode_cwd(slug: str) -> str:
+    """Reconstruct CWD from project directory slug.
+
+    Slug convention: /Users/sam/repo → -Users-sam-repo
+    Uses greedy filesystem walk to resolve ambiguous dashes.
+    Falls back to naive dash→slash replacement.
+    """
+    if not slug or slug == "-":
+        return "/"
+    # Remove leading dash
+    raw = slug.lstrip("-")
+    # Try greedy filesystem walk
+    parts = raw.split("-")
+    resolved = "/"
+    i = 0
+    while i < len(parts):
+        # Try longest match first (handles dirs with dashes in name)
+        found = False
+        for j in range(len(parts), i, -1):
+            candidate = "-".join(parts[i:j])
+            test_path = os.path.join(resolved, candidate)
+            if os.path.exists(test_path):
+                resolved = test_path
+                i = j
+                found = True
+                break
+        if not found:
+            # No match on disk — use single component
+            resolved = os.path.join(resolved, parts[i])
+            i += 1
+    return resolved
 
 
 def _session_revision_signature(session_dir: Path) -> tuple[str, str]:
@@ -54,7 +90,9 @@ def _session_revision_signature(session_dir: Path) -> tuple[str, str]:
         return datetime.now(tz=UTC).isoformat(), "0:0"
 
 
-def _read_session_meta(session_dir: Path) -> dict[str, Any]:
+def _read_session_meta(
+    session_dir: Path, project_slug: str | None = None
+) -> dict[str, Any]:
     """Extract lightweight metadata from a single session directory."""
     # Try to read CWD from session-info.json
     cwd: str | None = None
@@ -104,6 +142,10 @@ def _read_session_meta(session_dir: Path) -> dict[str, Any]:
                         cwd = normalized
     except (OSError, json.JSONDecodeError):
         pass
+
+    # Final fallback: decode CWD from project slug
+    if cwd is None and project_slug is not None:
+        cwd = _decode_cwd(project_slug)
 
     transcript_path = session_dir / TRANSCRIPT_FILENAME
     message_count = 0
@@ -159,31 +201,44 @@ def _read_session_meta(session_dir: Path) -> dict[str, Any]:
     }
 
 
-def _iter_session_dirs(sessions_dir: Path) -> list[Path]:
-    """Return validated session directories under sessions_dir."""
-    if not sessions_dir.exists():
-        return []
+def _iter_session_dirs(projects_dir: Path) -> Iterator[tuple[Path, str]]:
+    """Iterate session dirs in projects/{slug}/sessions/{id}/ layout.
 
+    Yields (session_dir, project_slug) tuples.
+    """
+    if not projects_dir or not projects_dir.is_dir():
+        return
     try:
-        children = list(sessions_dir.iterdir())
+        resolved_root = projects_dir.resolve()
     except OSError:
-        logger.warning(
-            "Could not list sessions at %s", sessions_dir, exc_info=True
-        )
-        return []
-
-    session_dirs: list[Path] = []
-    for child in children:
-        if not child.is_dir():
+        return
+    for project_dir in sorted(projects_dir.iterdir()):
+        if not project_dir.is_dir():
             continue
-        if not _VALID_SESSION_ID_RE.fullmatch(child.name):
-            logger.debug(
-                "Skipping session dir with non-standard name: %r", child.name
+        # Symlink containment
+        try:
+            if not project_dir.resolve().is_relative_to(resolved_root):
+                continue
+        except (OSError, ValueError):
+            continue
+        sessions_subdir = project_dir / "sessions"
+        if not sessions_subdir.is_dir():
+            continue
+        try:
+            for session_dir in sessions_subdir.iterdir():
+                if not session_dir.is_dir():
+                    continue
+                if not _VALID_SESSION_ID_RE.match(session_dir.name):
+                    logger.debug(
+                        "Skipping session dir with non-standard name: %r",
+                        session_dir.name,
+                    )
+                    continue
+                yield session_dir, project_dir.name
+        except OSError:
+            logger.warning(
+                "Could not list sessions in %s", sessions_subdir, exc_info=True
             )
-            continue
-        session_dirs.append(child)
-
-    return session_dirs
 
 
 def _dir_mtime(session_dir: Path) -> float:
@@ -197,11 +252,13 @@ def _dir_mtime(session_dir: Path) -> float:
 
 
 def scan_sessions(
-    sessions_dir: Path | None,
+    projects_dir: Path | None,
     limit: int = 200,
     offset: int = 0,
 ) -> tuple[list[dict[str, Any]], int]:
-    """Scan sessions_dir and return lightweight metadata for the requested page.
+    """Scan projects_dir and return lightweight metadata for the requested page.
+
+    Walks the two-level projects/{slug}/sessions/{id}/ tree.
 
     Two-phase algorithm for efficiency at scale:
       Phase 1 — cheap stat() all session dirs (~0.03 s for 5 000 dirs).
@@ -215,15 +272,15 @@ def scan_sessions(
 
     Never raises — malformed sessions are included with degraded metadata.
     """
-    if sessions_dir is None:
+    if projects_dir is None:
         return [], 0
 
     # Phase 1: cheap stat — discover and sort without reading transcripts
-    all_dirs = _iter_session_dirs(sessions_dir)
-    all_dirs.sort(key=_dir_mtime, reverse=True)
-    total_count = len(all_dirs)
+    all_entries = list(_iter_session_dirs(projects_dir))
+    all_entries.sort(key=lambda t: _dir_mtime(t[0]), reverse=True)
+    total_count = len(all_entries)
 
-    window = all_dirs[offset : offset + limit]
+    window = all_entries[offset : offset + limit]
     if not window:
         return [], total_count
 
@@ -231,9 +288,12 @@ def scan_sessions(
     results: list[dict[str, Any]] = []
     max_workers = min(8, len(window))
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        future_map = {pool.submit(_read_session_meta, d): d for d in window}
+        future_map = {
+            pool.submit(_read_session_meta, d, slug): (d, slug)
+            for d, slug in window
+        }
         for future in as_completed(future_map):
-            session_dir = future_map[future]
+            session_dir, _slug = future_map[future]
             try:
                 meta = future.result()
                 results.append(meta)
@@ -250,7 +310,7 @@ def scan_sessions(
 
 
 def scan_session_revisions(
-    sessions_dir: Path | None,
+    projects_dir: Path | None,
     session_ids: set[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Return lightweight revision metadata for session directories on disk.
@@ -258,13 +318,13 @@ def scan_session_revisions(
     Includes name/description from metadata.json so the frontend can update
     session titles without a full history fetch.
     """
-    if sessions_dir is None:
+    if projects_dir is None:
         return []
 
     wanted = set(session_ids) if session_ids is not None else None
 
     rows: list[dict[str, Any]] = []
-    for session_dir in _iter_session_dirs(sessions_dir):
+    for session_dir, _slug in _iter_session_dirs(projects_dir):
         session_id = session_dir.name
         if wanted is not None and session_id not in wanted:
             continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from chat_plugin import create_router
 
 
 class MockSettings:
-    sessions_dir = None
+    projects_dir = None
 
 
 class MockState:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -87,14 +87,15 @@ def test_api_pin_and_unpin(client):
 def test_history_with_sessions_on_disk(client, tmp_path, state):
     import json
 
-    state.settings.sessions_dir = tmp_path
-    sess_dir = tmp_path / "my-session"
-    sess_dir.mkdir()
+    # Two-level layout: projects/{slug}/sessions/{id}/
+    state.settings.projects_dir = tmp_path
+    sess_dir = tmp_path / "-Users-test" / "sessions" / "my-session"
+    sess_dir.mkdir(parents=True)
     (sess_dir / "transcript.jsonl").write_text(
         json.dumps({"role": "user", "content": "hello"}) + "\n",
         encoding="utf-8",
     )
-    # Re-create app with sessions_dir set
+    # Re-create app with projects_dir set
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
     from chat_plugin import create_router

--- a/tests/test_session_history.py
+++ b/tests/test_session_history.py
@@ -3,6 +3,21 @@ import json
 from chat_plugin.session_history import scan_session_revisions, scan_sessions
 
 
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _make_session(projects_dir, session_id, slug="-Users-test", transcript=None, metadata=None):
+    """Create a session in the two-level projects/{slug}/sessions/{id}/ layout."""
+    session_dir = projects_dir / slug / "sessions" / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    if transcript is not None:
+        (session_dir / "transcript.jsonl").write_text(transcript, encoding="utf-8")
+    if metadata is not None:
+        (session_dir / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+    return session_dir
+
+
+# ── basic coverage ────────────────────────────────────────────────────────────
+
 def test_scan_sessions_none_dir():
     sessions, total = scan_sessions(None)
     assert sessions == []
@@ -16,13 +31,13 @@ def test_scan_sessions_empty_dir(tmp_path):
 
 
 def test_scan_sessions_with_transcript(tmp_path):
-    session_dir = tmp_path / "sess-abc"
-    session_dir.mkdir()
-    transcript = session_dir / "transcript.jsonl"
-    transcript.write_text(
-        json.dumps({"role": "user", "content": "Hello"}) + "\n"
-        + json.dumps({"role": "assistant", "content": "Hi"}) + "\n",
-        encoding="utf-8",
+    _make_session(
+        tmp_path,
+        "sess-abc",
+        transcript=(
+            json.dumps({"role": "user", "content": "Hello"}) + "\n"
+            + json.dumps({"role": "assistant", "content": "Hi"}) + "\n"
+        ),
     )
     results, total = scan_sessions(tmp_path)
     assert total == 1
@@ -35,19 +50,15 @@ def test_scan_sessions_with_transcript(tmp_path):
 
 
 def test_scan_sessions_with_metadata(tmp_path):
-    session_dir = tmp_path / "sess-xyz"
-    session_dir.mkdir()
-    (session_dir / "transcript.jsonl").write_text(
-        json.dumps({"role": "user", "content": "test"}) + "\n",
-        encoding="utf-8",
-    )
-    (session_dir / "metadata.json").write_text(
-        json.dumps({
+    _make_session(
+        tmp_path,
+        "sess-xyz",
+        transcript=json.dumps({"role": "user", "content": "test"}) + "\n",
+        metadata={
             "name": "My Session",
             "description": "A test session",
             "parent_id": "sess-parent",
-        }),
-        encoding="utf-8",
+        },
     )
     results, total = scan_sessions(tmp_path)
     assert total == 1
@@ -59,11 +70,10 @@ def test_scan_sessions_with_metadata(tmp_path):
 
 
 def test_scan_session_revisions(tmp_path):
-    session_dir = tmp_path / "sess-rev"
-    session_dir.mkdir()
-    (session_dir / "transcript.jsonl").write_text(
-        json.dumps({"role": "user", "content": "hi"}) + "\n",
-        encoding="utf-8",
+    _make_session(
+        tmp_path,
+        "sess-rev",
+        transcript=json.dumps({"role": "user", "content": "hi"}) + "\n",
     )
     rows = scan_session_revisions(tmp_path)
     assert len(rows) == 1
@@ -74,9 +84,7 @@ def test_scan_session_revisions(tmp_path):
 
 def test_scan_session_revisions_filter(tmp_path):
     for name in ["sess-a", "sess-b", "sess-c"]:
-        d = tmp_path / name
-        d.mkdir()
-        (d / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
+        _make_session(tmp_path, name, transcript="{}\n")
     rows = scan_session_revisions(tmp_path, session_ids={"sess-b"})
     assert len(rows) == 1
     assert rows[0]["session_id"] == "sess-b"
@@ -87,9 +95,11 @@ def test_scan_session_revisions_none_dir():
 
 
 def test_invalid_session_ids_skipped(tmp_path):
-    (tmp_path / "valid-id").mkdir()
-    (tmp_path / ".hidden").mkdir()
-    (tmp_path / "has spaces").mkdir()
+    _make_session(tmp_path, "valid-id", transcript="{}\n")
+    # Create malformed dirs directly — they sit at the sessions/ level
+    bad_sessions = tmp_path / "-Users-test" / "sessions"
+    (bad_sessions / ".hidden").mkdir()
+    (bad_sessions / "has spaces").mkdir()
     results, total = scan_sessions(tmp_path)
     session_ids = {r["session_id"] for r in results}
     assert "valid-id" in session_ids
@@ -102,10 +112,10 @@ def test_scan_sessions_pagination(tmp_path):
     import time
 
     for name in ["sess-oldest", "sess-middle", "sess-newest"]:
-        d = tmp_path / name
-        d.mkdir()
-        (d / "transcript.jsonl").write_text(
-            '{"role": "user", "content": "hi"}\n', encoding="utf-8"
+        _make_session(
+            tmp_path,
+            name,
+            transcript='{"role": "user", "content": "hi"}\n',
         )
         time.sleep(0.01)  # ensure distinct mtimes
 
@@ -126,10 +136,10 @@ def test_scan_sessions_pagination(tmp_path):
 def test_scan_sessions_total_count(tmp_path):
     """total_count equals the number of valid session directories."""
     for name in ["sess-a", "sess-b", "sess-c"]:
-        d = tmp_path / name
-        d.mkdir()
-        (d / "transcript.jsonl").write_text(
-            '{"role": "user", "content": "x"}\n', encoding="utf-8"
+        _make_session(
+            tmp_path,
+            name,
+            transcript='{"role": "user", "content": "x"}\n',
         )
 
     _, total = scan_sessions(tmp_path)
@@ -139,3 +149,31 @@ def test_scan_sessions_total_count(tmp_path):
     page, total2 = scan_sessions(tmp_path, limit=10, offset=100)
     assert total2 == 3
     assert page == []
+
+
+def test_scan_sessions_cwd_from_slug(tmp_path):
+    """CWD is decoded from project slug when session-info.json is absent."""
+    _make_session(
+        tmp_path,
+        "sess-cwd",
+        slug="-Users-test-myproject",
+        transcript='{"role": "user", "content": "cwd test"}\n',
+    )
+    results, total = scan_sessions(tmp_path)
+    assert total == 1
+    row = results[0]
+    # Naive fallback: -Users-test-myproject → /Users/test/myproject (or longer match)
+    assert row["cwd"] is not None
+    assert row["cwd"].startswith("/")
+
+
+def test_scan_sessions_multiple_projects(tmp_path):
+    """Sessions from different project slugs are all returned."""
+    _make_session(tmp_path, "sess-1", slug="-Users-alice-projA",
+                  transcript='{"role": "user", "content": "a"}\n')
+    _make_session(tmp_path, "sess-2", slug="-Users-bob-projB",
+                  transcript='{"role": "user", "content": "b"}\n')
+    results, total = scan_sessions(tmp_path)
+    assert total == 2
+    ids = {r["session_id"] for r in results}
+    assert ids == {"sess-1", "sess-2"}


### PR DESCRIPTION
## Summary

Updates plugin-chat's session history scanner to read the CLI's project-nested `~/.amplifier/projects/{slug}/sessions/{id}/` layout instead of the flat `~/.amplifier/sessions/` layout. This makes all historical CLI/distro sessions (~5,696) visible in the sidebar.

Companion to microsoft/amplifierd#5
Fixes microsoft/amplifier-distro#177

### Changes

| File | What Changed |
|------|-------------|
| `session_history.py` | Added `_decode_cwd()` (greedy FS walk to reconstruct CWD from slug). Rewrote `_iter_session_dirs()` for two-level `projects/*/sessions/*/` walk. Updated `scan_sessions()` and `scan_session_revisions()` signatures |
| `__init__.py` | Reads `state.settings.projects_dir` instead of `sessions_dir` |
| `routes.py` | Parameter rename `sessions_dir` → `projects_dir` throughout |

### Tests
57/57 passing