### PR TITLE
fix: sync mode banner state per-session

### DIFF
--- a/src/chat_plugin/static/index.html
+++ b/src/chat_plugin/static/index.html
@@ -6602,6 +6602,14 @@
         if (!res.ok) return;
         const data = await res.json();
         setDynamicShortcuts({ modes: data.modes || [], skills: data.skills || [] });
+        // Sync active mode from backend (source of truth for per-session mode state).
+        // This ensures the mode banner reflects the target session after switches.
+        if (data.active_mode) {
+          const modeInfo = (data.modes || []).find(m => m.name === data.active_mode);
+          setActiveMode({ name: data.active_mode, description: modeInfo?.description || '' });
+        } else {
+          setActiveMode(null);
+        }
       } catch (e) { /* silent */ }
     }, []);
 
@@ -7924,6 +7932,10 @@
               ? { ...item, toolStatus: msg.success ? 'complete' : 'error', result: msg.output, resultError: msg.error }
               : item
           ));
+          // When the agent uses the mode tool, re-sync mode banner from backend.
+          if (msg.tool_name === 'mode' && sessionIdRef.current) {
+            fetchShortcuts(sessionIdRef.current);
+          }
           break;
         }
 
@@ -9359,6 +9371,8 @@
             ...cur,
             savedItems: chronoItemsRef.current,
             savedTurnCount: turnCountRef.current,
+            savedActiveMode: activeMode,
+            savedDynamicShortcuts: dynamicShortcuts,
           });
           return next;
         });
@@ -9370,6 +9384,8 @@
       setChronoItems([]);
       orderCounterRef.current = 0;
       setTurnCount(0);
+      // New sessions have no active mode - clear the banner.
+      setActiveMode(null);
       setHoveredTurnId(null);
       setActiveTurnId(null);
       setSelectedTurnId(null);
@@ -9441,6 +9457,8 @@
             ...cur,
             savedItems: chronoItemsRef.current,
             savedTurnCount: turnCountRef.current,
+            savedActiveMode: activeMode,
+            savedDynamicShortcuts: dynamicShortcuts,
           });
           return next;
         });
@@ -9451,6 +9469,10 @@
       setMobileSidebarOpen(false);
       setExecuting(false);
       setPendingApproval(null);
+      // Restore saved mode for instant UI (no flash); fetchShortcuts will
+      // reconcile with the backend once the session is resumed.
+      setActiveMode(target.savedActiveMode || null);
+      setDynamicShortcuts(target.savedDynamicShortcuts || { modes: [], skills: [] });
       setHoveredTurnId(null);
       setActiveTurnId(null);
       setSelectedTurnId(null);


### PR DESCRIPTION
Fixes a bug where the mode banner (`/plan`, `/brainstorm`) was not properly tied to individual sessions.

## Problem
Activating a mode in Session A, then switching to Session B would show the banner in Session B. Switching back to Session A would lose the banner.

## Root Cause
`activeMode` is global React state. `switchSession` correctly saved/restored it per-session, but `resumeHistorySession` and `newSession` did not. Additionally, `fetchShortcuts` received `active_mode` from the backend but ignored it.

## Changes

1. **fetchShortcuts** (line ~6602): Use `data.active_mode` from backend response to sync the mode banner. Makes the backend the authoritative source of truth for per-session mode state.

2. **resumeHistorySession** (line ~9452): Save `savedActiveMode` and `savedDynamicShortcuts` when switching away from current session. Restore from `target.savedActiveMode` when entering the target session (instant, no flash). `fetchShortcuts` reconciles with the backend afterward.

3. **newSession** (line ~9366): Same save pattern when switching away. Clear mode for new session since new sessions have no active mode.

4. **tool_result handler** (line ~7935): When the agent uses the mode tool mid-conversation, call `fetchShortcuts` to sync the banner from the backend.

## Testing
All 448 existing tests pass.